### PR TITLE
add `toLowerCase()` for file extention

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ function getEmbedType(node: HTMLElement) {
     return null;
   }
 
-  const ext = src.split(".").pop();
+  const ext = src.split(".").pop()?.toLowerCase();
 
   if (imageExt.contains(ext)) return "image";
   if (audioExt.contains(ext)) return "audio";


### PR DESCRIPTION
fixes #10. Not sure if case variation is appropriate for file extensions in general though.