### PR TITLE
Due to the support for AVIF in Obsidian 1.5.3, we also need to add su…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { MarkdownPostProcessorContext, Plugin } from "obsidian";
 
-const imageExt = ["bmp", "png", "jpg", "jpeg", "gif", "svg", "webp"];
+const imageExt = ["bmp", "png", "jpg", "jpeg", "gif", "svg", "webp", "avif"];
 const audioExt = ["mp3", "wav", "m4a", "3gp", "flac", "ogg", "oga"];
 const videoExt = ["mp4", "webm", "ogv"];
 


### PR DESCRIPTION
Due to the support for AVIF in Obsidian 1.5.3, we also need to add support to generate the correct CSS class. Some themes rely on the 'el-embed-image' CSS class to function properly.